### PR TITLE
Add SOCD cleaner for QMK

### DIFF
--- a/software/QMK/keymaps/default/config.h
+++ b/software/QMK/keymaps/default/config.h
@@ -25,7 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    leafcutterlabs
 #define PRODUCT         vsfighter2
-#define DESCRIPTION     16-key
 
 /* key matrix size */
 #define MATRIX_ROWS 1

--- a/software/QMK/rules.mk
+++ b/software/QMK/rules.mk
@@ -29,7 +29,7 @@ UNICODE_ENABLE = yes        # Unicode
 BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 RGBLIGHT_ENABLE = yes       # Enable WS2812 RGB underlight.
 TAP_DANCE_ENABLE = no      # Double press does something different
-JOYSTICK_ENABLE = analog  #analog digital, no
+JOYSTICK_ENABLE = no  #analog digital, no
 
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no    # Breathing sleep LED during USB suspend

--- a/software/QMK/vsfighter2.c
+++ b/software/QMK/vsfighter2.c
@@ -3,3 +3,167 @@
 void matrix_init_kb(void) {
 	matrix_init_user();
 }
+
+#if defined(SOCD_CLEANER_LRN_UDU) || defined(SOCD_CLEANER_LAST_INPUT_WINS)
+static uint16_t key_up;
+static uint16_t key_down;
+static uint16_t key_left;
+static uint16_t key_right;
+
+static bool pressed_up = false;
+static bool pressed_down = false;
+static bool pressed_left = false;
+static bool pressed_right = false;
+
+#ifdef SOCD_CLEANER_LAST_INPUT_WINS
+static bool up_wins = false;
+static bool left_wins = false;
+#endif
+
+void keyboard_post_init_user(void) {
+	/*
+	 * Read keymap from progmem after initialization. Only supports one layer.
+	 * TODO: Figure out how to work with dynamic keymaps (VIA)
+	 */
+	key_up = pgm_read_word(&keymaps[0][0][0]);
+	key_down = pgm_read_word(&keymaps[0][0][1]);
+	key_left = pgm_read_word(&keymaps[0][0][2]);
+	key_right = pgm_read_word(&keymaps[0][0][3]);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+#ifdef SOCD_CLEANER_LRN_UDU
+	/*
+	 * Left + Right = Neutral
+	 * Up + Down = Up
+	 */
+	if (keycode == key_up) {
+		if (record->event.pressed) {
+			pressed_up = true;
+			if (pressed_down) {
+				unregister_code(key_down);
+				return true;
+			}
+		} else {
+			pressed_up = false;
+			if (pressed_down) {
+				register_code(key_down);
+				return true;
+			}
+		}
+	} else if (keycode == key_down) {
+		if (record->event.pressed) {
+			pressed_down = true;
+			if (pressed_up) {
+				return false;
+			}
+		} else {
+			pressed_down = false;
+			if (pressed_up) {
+				return false;
+			}
+		}
+	} else if (keycode == key_left) {
+		if (record->event.pressed) {
+			pressed_left = true;
+			if (pressed_right) {
+				unregister_code(key_right);
+				return false;
+			}
+		} else {
+			pressed_left = false;
+			if (pressed_right) {
+				register_code(key_right);
+				return false;
+			}
+		}
+	} else if (keycode == key_right) {
+		if (record->event.pressed) {
+			pressed_right = true;
+			if (pressed_left) {
+				unregister_code(key_left);
+				return false;
+			}
+		} else {
+			pressed_right = false;
+			if (pressed_left) {
+				register_code(key_left);
+				return false;
+			}
+		}
+	}
+#else
+	/* Last input wins */
+	if (keycode == key_up) {
+		if (record->event.pressed) {
+			pressed_up = true;
+			if (pressed_down) {
+				unregister_code(key_down);
+				up_wins = true;
+			}
+		} else {
+			pressed_up = false;
+			if (pressed_down) {
+				if (up_wins) {
+					register_code(key_down);
+				} else {
+					return false;
+				}
+			}
+		}
+	} else if (keycode == key_down) {
+		if (record->event.pressed) {
+			pressed_down = true;
+			if (pressed_up) {
+				unregister_code(key_up);
+				up_wins = false;
+			}
+		} else {
+			pressed_down = false;
+			if (pressed_up) {
+				if (!up_wins) {
+					register_code(key_up);
+				} else {
+					return false;
+				}
+			}
+		}
+	} else if (keycode == key_left) {
+		if (record->event.pressed) {
+			pressed_left = true;
+			if (pressed_right) {
+				unregister_code(key_right);
+				left_wins = true;
+			}
+		} else {
+			pressed_left = false;
+			if (pressed_right) {
+				if (left_wins) {
+					register_code(key_right);
+				} else {
+					return false;
+				}
+			}
+		}
+	} else if (keycode == key_right) {
+		if (record->event.pressed) {
+			pressed_right = true;
+			if (pressed_left) {
+				unregister_code(key_left);
+				left_wins = false;
+			}
+		} else {
+			pressed_right = false;
+			if (pressed_left) {
+				if (!left_wins) {
+					register_code(key_left);
+				} else {
+					return false;
+				}
+			}
+		}
+	}
+#endif
+	return true;
+}
+#endif


### PR DESCRIPTION
SOCD cleaning methods implemented:
1. Left + Right = Neutral, Up + Down = Up
2. Last input wins

Key codes read from keymap at initialization time to work regardless of key codes configured in keymap.c

New to the QMK code base, not sure how to support dynamic keymaps (VIA) yet.